### PR TITLE
Additional criteria to stop reading geom. in ppl

### DIFF
--- a/pyfas/ppl.py
+++ b/pyfas/ppl.py
@@ -92,7 +92,7 @@ class Ppl:
                     except ValueError:
                         pass
                 raw_geometry.extend(points)
-                if 'CATALOG' in line or 'BRANCH' in line:
+                if ('CATALOG' in line) or ('BRANCH' in line) or ('ANNULUS' in line):
                     break
         xy_geo = raw_geometry
         self.geometries[branch] = (xy_geo[:int(len(xy_geo)/2)],


### PR DESCRIPTION
Fixing a bug I found when there was an ANNULUS geometry following the BRANCH geometry, failing to fall into the break condition, appending extra incorrect values to raw_geometry.