### PR TITLE
Fix p_array & t_array for tab files with T & P ranges

### DIFF
--- a/pyfas/tab.py
+++ b/pyfas/tab.py
@@ -107,9 +107,9 @@ class Tab():
                     len_t_array = self.metadata['t_points'][fluid_idx]
                     len_p_array = self.metadata['p_points'][fluid_idx]
 
-        self.metadata['p_array'].append(t_p[:len_p_array])
-        self.metadata['t_array'].append(t_p[len_p_array:
-                                            len_t_array+len_p_array])
+                    self.metadata['p_array'].append(t_p[:len_p_array])
+                    self.metadata['t_array'].append(t_p[len_p_array:
+                                                        len_t_array+len_p_array])
         self.data = pd.DataFrame(props_idx,
                                  index=("Fluid", "Property",
                                         "Unit")).transpose()


### PR DESCRIPTION
Small indentation changes (3 lines) to correct a runtime error when processing files with T & P points defined as ranges, such as the one below.

```
                    'WATER-OPTION ENTROPY 'P-2-rich EOS = PR
                        42   35    .205826E-01
                       .487805E+06    .882353E+01
                       .100000E+06   -.500000E+02

```

Cause:
- `t_p` referenced outside of scope

Fix:
- Move out-of-scope reference to proper scope 