### PR TITLE
Update ppl.py prevent it to fail when using SOLIDBUNDLE (and other olga keyword)

### DIFF
--- a/pyfas/ppl.py
+++ b/pyfas/ppl.py
@@ -104,7 +104,7 @@ class Ppl:
                     except ValueError:
                         pass
                 raw_geometry.extend(points)
-                if ('CATALOG' in line) or ('BRANCH' in line) or ('ANNULUS' in line):
+                if re.search(r"[A-DF-Z]", line) is not None:
                     break
         xy_geo = raw_geometry
         self.geometries[branch] = (xy_geo[:int(len(xy_geo)/2)],
@@ -301,6 +301,7 @@ class Ppl:
         print('====')
         print('Props:')
         pprint( self._branches_and_props, compact= True, width= 200)
+
 
 
 


### PR DESCRIPTION
change from 
`if ('CATALOG' in line) or ('BRANCH' in line) or ('ANNULUS' in line):` to `if re.search(r"[A-DF-Z]", line) is not None:`

This is to account for the run that has solid bundle. When the word `SOLIDBUNDLE` is in the geometry definition of the ppl file, the parsing of geometry fail.

The geometry data should not have any letters A-Z except letter E for the scientific notation. Other than SOLIDBUNDLE, there could be something else that is not being accounted for, so I set the break for all cases that has any letter except letter e, E

I tested on my machine, and it works well. Cheers.